### PR TITLE
Move on to Mapnik 3.x

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -40,6 +40,8 @@
 				<pathelement location="build/classes-test"/>
 			</classpath>
 			
+			<sysproperty key="java.library.path" value="build/dist/"/>
+			
 			<formatter type="plain"/>
 
 			<batchtest todir="build/testresults">

--- a/build.xml
+++ b/build.xml
@@ -5,9 +5,9 @@
 	<target name="compile">
 		<mkdir dir="build/classes"/>
 		<mkdir dir="csrc"/>
-		<javac srcdir="src" destdir="build/classes" debug="on" source="1.5" target="1.5" includeantruntime="false"/>
+		<javac srcdir="src" destdir="build/classes" debug="on" source="1.6" target="1.6" includeantruntime="false"/>
 		<mkdir dir="build/classes-tools"/>
-		<javac srcdir="tools" destdir="build/classes-tools" debug="on" source="1.5" target="1.5" includeantruntime="false">
+		<javac srcdir="tools" destdir="build/classes-tools" debug="on" source="1.6" target="1.6" includeantruntime="false">
 			<classpath>
 				<pathelement location="build/classes"/>
 			</classpath>
@@ -26,7 +26,7 @@
 	<target name="test" depends="jar,native">
 		<mkdir dir="build/classes-test"/>
 		<mkdir dir="build/testresults"/>
-		<javac srcdir="test" destdir="build/classes-test" debug="on" source="1.5" target="1.5" includeantruntime="false">
+		<javac srcdir="test" destdir="build/classes-test" debug="on" source="1.6" target="1.6" includeantruntime="false">
 			<classpath>
 				<pathelement location="${junit.jar}"/>
 				<pathelement location="build/dist/mapnik-jni.jar"/>
@@ -63,7 +63,7 @@
 			access="public"
 			encoding="UTF-8"
 			windowtitle="mapnik-jni API documentation"
-			source="1.5"
+			source="1.6"
 		/>
 	</target>
 	

--- a/csrc/Makefile.osx
+++ b/csrc/Makefile.osx
@@ -9,7 +9,8 @@ libmapnik-jni.jnilib: $(SOURCE_DEPENDS)
 		$(JAVA_CFLAGS) \
 		mapnikjni.cpp \
 		$(LDFLAGS) \
-		$(MAPNIK_LIBS) -framework JavaVM
+		$(JAVA_LDFLAGS) \
+		$(MAPNIK_LIBS)
 	
 clean:
 	rm libmapnik-jni.jnilib

--- a/csrc/class_featureset.cpp
+++ b/csrc/class_featureset.cpp
@@ -171,7 +171,7 @@ jobject operator()(value_integer value) const {
 	}
 
 	jobject operator()(icu::UnicodeString const& value) const {
-		return env->NewString(value.getBuffer(), value.length());
+		return env->NewString(reinterpret_cast<const jchar*>(value.getBuffer()), value.length());
 	}
 
 	jobject operator()(mapnik::value_null const& value) const {

--- a/csrc/class_featuretypestyle.cpp
+++ b/csrc/class_featuretypestyle.cpp
@@ -40,7 +40,7 @@ JNIEXPORT jobject JNICALL Java_mapnik_FeatureTypeStyle_collectAttributes
 
 	std::set<std::string> attrs;
 	mapnik::attribute_collector collector(attrs);
-	BOOST_FOREACH(mapnik::rule const& r, rules) {
+	for (mapnik::rule const& r : rules) {
 		collector(r);
 	}
 

--- a/csrc/class_geometry.cpp
+++ b/csrc/class_geometry.cpp
@@ -8,10 +8,26 @@ JNIEXPORT jint JNICALL Java_mapnik_Geometry_getType
   (JNIEnv *env, jobject gobj)
 {
 	PREAMBLE;
-	mapnik::geometry_type* g=LOAD_GEOMETRY_POINTER(gobj);
-	return g->type();
+	mapnik::geometry::geometry<double>* g=LOAD_GEOMETRY_POINTER(gobj);
+	return mapnik::geometry::geometry_type(*g);
 	TRAILER(0);
 }
+
+
+struct VertexCollector
+{
+	std::vector<std::tuple<unsigned, double, double>> vertices;
+
+	template<typename T>
+	void operator()(const T &vertex_adapter)
+	{
+		unsigned command;
+		double x, y;
+		while ((command = vertex_adapter.vertex(&x, &y)) != mapnik::SEG_END)
+			vertices.push_back(std::make_tuple(command, x, y));
+	}
+};
+
 
 /*
  * Class:     mapnik_Geometry
@@ -22,12 +38,13 @@ JNIEXPORT jint JNICALL Java_mapnik_Geometry_getNumPoints
   (JNIEnv *env, jobject gobj)
 {
 	PREAMBLE;
-	mapnik::geometry_type* g=LOAD_GEOMETRY_POINTER(gobj);
-	#if MAPNIK_VERSION >= 200100
-	return g->size();
-	#else
-	return g->num_points();
-	#endif
+	mapnik::geometry::geometry<double>* g = LOAD_GEOMETRY_POINTER(gobj);
+
+	VertexCollector vertex_collector;
+	mapnik::geometry::vertex_processor<VertexCollector> processor(vertex_collector);
+	processor(*g);
+
+	return vertex_collector.vertices.size();
 	TRAILER(0);
 }
 
@@ -40,20 +57,19 @@ JNIEXPORT jint JNICALL Java_mapnik_Geometry_getVertex
   (JNIEnv *env, jobject gobj, jint pos, jobject coord)
 {
 	PREAMBLE;
-	mapnik::geometry_type* g=LOAD_GEOMETRY_POINTER(gobj);
-	double x=0, y=0;
-	#if MAPNIK_VERSION >= 200100
-	unsigned ret=g->vertex(pos, &x, &y);
-	#else
-	unsigned ret=g->get_vertex(pos, &x, &y);
-	#endif
+	mapnik::geometry::geometry<double>* g=LOAD_GEOMETRY_POINTER(gobj);
+
+	VertexCollector vertex_collector;
+	mapnik::geometry::vertex_processor<VertexCollector> processor(vertex_collector);
+	processor(*g);
+	const std::tuple<unsigned, double, double> &command_and_coords = vertex_collector.vertices.at(pos);
 
 	if (coord) {
-		env->SetDoubleField(coord, FIELD_COORD_X, x);
-		env->SetDoubleField(coord, FIELD_COORD_Y, y);
+		env->SetDoubleField(coord, FIELD_COORD_X, std::get<1>(command_and_coords));
+		env->SetDoubleField(coord, FIELD_COORD_Y, std::get<2>(command_and_coords));
 	}
 
-	return ret;
+	return std::get<0>(command_and_coords);
 	TRAILER(0);
 }
 
@@ -66,8 +82,8 @@ JNIEXPORT jobject JNICALL Java_mapnik_Geometry_getEnvelope
   (JNIEnv *env, jobject gobj)
 {
 	PREAMBLE;
-	mapnik::geometry_type* g=LOAD_GEOMETRY_POINTER(gobj);
-	return box2dFromNative(env, g->envelope());
+	mapnik::geometry::geometry<double>* g=LOAD_GEOMETRY_POINTER(gobj);
+	return box2dFromNative(env, mapnik::geometry::envelope(*g));
 	TRAILER(0);
 }
 

--- a/csrc/class_image.cpp
+++ b/csrc/class_image.cpp
@@ -7,7 +7,7 @@ JNIEXPORT jlong JNICALL Java_mapnik_Image_alloc__II
   (JNIEnv *env, jclass c, jint width, jint height)
 {
 	PREAMBLE;
-	mapnik::image_32* im=new mapnik::image_32(width, height);
+	mapnik::image_rgba8* im=new mapnik::image_rgba8(width, height);
 	return FROM_POINTER(im);
 	TRAILER(0);
 }
@@ -25,9 +25,9 @@ JNIEXPORT jlong JNICALL Java_mapnik_Image_alloc__Lmapnik_Image_2
 		throw_runtime_exception(env, "Image cannot be null in call to constructor");
 		return 0;
 	}
-	mapnik::image_32* other=LOAD_IMAGE_POINTER(iobjother);
+	mapnik::image_rgba8* other=LOAD_IMAGE_POINTER(iobjother);
 
-	mapnik::image_32* im=new mapnik::image_32(*other);
+	mapnik::image_rgba8* im=new mapnik::image_rgba8(*other);
 	return FROM_POINTER(im);
 
 	TRAILER(0);
@@ -42,7 +42,7 @@ JNIEXPORT void JNICALL Java_mapnik_Image_dealloc
   (JNIEnv * env, jobject, jlong ptr)
 {
 	PREAMBLE;
-	mapnik::image_32* im=static_cast<mapnik::image_32*>(TO_POINTER(ptr));
+	mapnik::image_rgba8* im=static_cast<mapnik::image_rgba8*>(TO_POINTER(ptr));
 	if (im) {
 		delete im;
 	}
@@ -58,7 +58,7 @@ JNIEXPORT jint JNICALL Java_mapnik_Image_getWidth
   (JNIEnv *env, jobject imobj)
 {
 	PREAMBLE;
-	mapnik::image_32* im=LOAD_IMAGE_POINTER(imobj);
+	mapnik::image_rgba8* im=LOAD_IMAGE_POINTER(imobj);
 	return im->width();
 	TRAILER(0);
 }
@@ -72,7 +72,7 @@ JNIEXPORT jint JNICALL Java_mapnik_Image_getHeight
 (JNIEnv *env, jobject imobj)
 {
 	PREAMBLE;
-	mapnik::image_32* im=LOAD_IMAGE_POINTER(imobj);
+	mapnik::image_rgba8* im=LOAD_IMAGE_POINTER(imobj);
 	return im->height();
 	TRAILER(0);
 }
@@ -86,7 +86,7 @@ JNIEXPORT void JNICALL Java_mapnik_Image_saveToFile
   (JNIEnv *env, jobject imobj, jstring filenamej, jstring typej)
 {
 	PREAMBLE;
-	mapnik::image_32* im=LOAD_IMAGE_POINTER(imobj);
+	mapnik::image_rgba8* im=LOAD_IMAGE_POINTER(imobj);
 	refjavastring filename(env, filenamej);
 	refjavastring type(env, typej);
 
@@ -103,7 +103,7 @@ JNIEXPORT jbyteArray JNICALL Java_mapnik_Image_saveToMemory
   (JNIEnv *env, jobject imobj, jstring typej)
 {
 	PREAMBLE;
-	mapnik::image_32* im=LOAD_IMAGE_POINTER(imobj);
+	mapnik::image_rgba8* im=LOAD_IMAGE_POINTER(imobj);
 	refjavastring type(env, typej);
 
 	std::string datastring=mapnik::save_to_string(*im, type.stringz);

--- a/csrc/class_layer.cpp
+++ b/csrc/class_layer.cpp
@@ -149,7 +149,7 @@ JNIEXPORT jdouble JNICALL Java_mapnik_Layer_getMinZoom
 {
 	PREAMBLE;
 	mapnik::layer* layer=LOAD_LAYER_POINTER(layerobj);
-	return layer->min_zoom();
+	return layer->minimum_scale_denominator();
 	TRAILER(0);
 }
 
@@ -163,7 +163,7 @@ JNIEXPORT void JNICALL Java_mapnik_Layer_setMinZoom
 {
 	PREAMBLE;
 	mapnik::layer* layer=LOAD_LAYER_POINTER(layerobj);
-	layer->set_min_zoom(z);
+	layer->set_minimum_scale_denominator(z);
 	TRAILER_VOID;
 }
 
@@ -177,7 +177,7 @@ JNIEXPORT jdouble JNICALL Java_mapnik_Layer_getMaxZoom
 {
 	PREAMBLE;
 	mapnik::layer* layer=LOAD_LAYER_POINTER(layerobj);
-	return layer->max_zoom();
+	return layer->maximum_scale_denominator();
 	TRAILER(0);
 }
 
@@ -191,7 +191,7 @@ JNIEXPORT void JNICALL Java_mapnik_Layer_setMaxZoom
 {
 	PREAMBLE;
 	mapnik::layer* layer=LOAD_LAYER_POINTER(layerobj);
-	layer->set_max_zoom(z);
+	layer->set_maximum_scale_denominator(z);
 	TRAILER_VOID;
 }
 

--- a/csrc/class_map.cpp
+++ b/csrc/class_map.cpp
@@ -160,7 +160,7 @@ JNIEXPORT void JNICALL Java_mapnik_MapDefinition_removeLayer
 {
 	PREAMBLE;
 	mapnik::Map* map=LOAD_MAP_POINTER(mapobject);
-	map->removeLayer(index);
+	map->remove_layer(index);
 	TRAILER_VOID;
 }
 
@@ -179,7 +179,7 @@ JNIEXPORT void JNICALL Java_mapnik_MapDefinition_addLayer
 	mapnik::layer* layer=
 			static_cast<mapnik::layer*>(TO_POINTER(env->GetLongField(layerobject, FIELD_PTR)));
 
-	map->addLayer(*layer);
+	map->add_layer(*layer);
 	TRAILER_VOID;
 }
 

--- a/csrc/class_parameters.cpp
+++ b/csrc/class_parameters.cpp
@@ -5,12 +5,6 @@ static void translate_to_mapnik_parameters(JNIEnv *env, jobject javaparams, mapn
 	env->CallVoidMethod(javaparams, METHOD_PARAMETERS_COPY_TO_NATIVE, (jlong)(&mapnikparams));
 }
 
-#if MAPNIK_VERSION >= 200200
-	typedef mapnik::value_integer value_integer;
-#else
-	typedef int value_integer;
-#endif
-
 class translate_parameter_visitor: public boost::static_visitor<>
 {
 	JNIEnv *env;
@@ -20,7 +14,7 @@ public:
 	translate_parameter_visitor(JNIEnv* aenv, jobject aparamobject, jstring akey): env(aenv), paramobject(aparamobject), key(akey) {
 	}
 
-	void operator()(value_integer value) const {
+	void operator()(mapnik::value_integer value) const {
 #ifdef BIGINT
 		env->CallVoidMethod(paramobject, METHOD_PARAMETERS_SET_LONG, key, (jlong)value);
 #else
@@ -28,11 +22,11 @@ public:
 #endif
 	}
 
-	void operator()(bool value) const {
+	void operator()(mapnik::value_bool value) const {
 		env->CallVoidMethod(paramobject, METHOD_PARAMETERS_SET_BOOLEAN, key, (jboolean)value);
 	}
 
-	void operator()(double value) const {
+	void operator()(mapnik::value_double value) const {
 		env->CallVoidMethod(paramobject, METHOD_PARAMETERS_SET_DOUBLE, key, (jdouble)value);
 	}
 
@@ -59,7 +53,7 @@ JNIEXPORT void JNICALL Java_mapnik_Parameters_setNativeInt
 	PREAMBLE;
 	refjavastring name(env, namej);
 	mapnik::parameters *params=(mapnik::parameters*)(ptr);
-	(*params)[name.stringz]=static_cast<value_integer>(value);
+	(*params)[name.stringz]=static_cast<mapnik::value_integer>(value);
 	TRAILER_VOID;
 }
 

--- a/csrc/class_renderer.cpp
+++ b/csrc/class_renderer.cpp
@@ -13,9 +13,9 @@ JNIEXPORT void JNICALL Java_mapnik_Renderer_renderAgg
 	}
 
 	mapnik::Map* map=LOAD_MAP_POINTER(mapobj);
-	mapnik::image_32* im=LOAD_IMAGE_POINTER(imobj);
+	mapnik::image_rgba8* im=LOAD_IMAGE_POINTER(imobj);
 
-	mapnik::agg_renderer<mapnik::image_32> ren(*map, *im, scale_factor, offset_x, offset_y);
+	mapnik::agg_renderer<mapnik::image_rgba8> ren(*map, *im, scale_factor, offset_x, offset_y);
 	ren.apply();
 
 	TRAILER_VOID;

--- a/csrc/common.mk
+++ b/csrc/common.mk
@@ -1,6 +1,7 @@
 JAVA_CMD ?= java
 CFLAGS ?= 
 JAVA_CFLAGS ?= $(shell $(JAVA_CMD) -jar java-config.jar --cflags)
+JAVA_LDFLAGS ?= $(shell $(JAVA_CMD) -jar java-config.jar --ldflags)
 MAPNIK_CFLAGS = $(shell mapnik-config --cflags)
 FONTS_DIR = $(shell mapnik-config --fonts)
 INPUT_PLUGINS_DIR = $(shell mapnik-config --input-plugins)

--- a/csrc/globals.cpp
+++ b/csrc/globals.cpp
@@ -90,7 +90,7 @@ void throw_java_exception(JNIEnv* env, std::exception& e) {
 #define TO_POINTER(ptr) ((void*)ptr)
 #define FROM_POINTER(ptr) ((jlong)ptr)
 
-inline static long ASSERT_LONG_POINTER(long ptr) {
+inline static jlong ASSERT_LONG_POINTER(jlong ptr) {
 	if (!ptr) {
 		throw std::runtime_error("Object is no longer valid");
 	}

--- a/csrc/globals.cpp
+++ b/csrc/globals.cpp
@@ -112,8 +112,8 @@ inline static long ASSERT_LONG_POINTER(long ptr) {
 #define LOAD_QUERY_POINTER(object) (static_cast<mapnik::query*>(LOAD_OBJECT_POINTER(object)))
 #define LOAD_FEATURESET_POINTER(object) (static_cast<mapnik::featureset_ptr*>(LOAD_OBJECT_POINTER(object)))
 #define LOAD_FEATURE_POINTER(object) (static_cast<mapnik::feature_ptr*>(TO_POINTER(env->GetLongField(object, FIELD_FEATURESET_FEATURE_PTR))))
-#define LOAD_GEOMETRY_POINTER(object) (static_cast<mapnik::geometry_type*>(LOAD_OBJECT_POINTER(object)))
-#define LOAD_IMAGE_POINTER(object) (static_cast<mapnik::image_32*>(LOAD_OBJECT_POINTER(object)))
+#define LOAD_GEOMETRY_POINTER(object) (static_cast<mapnik::geometry::geometry<double>*>(LOAD_OBJECT_POINTER(object)))
+#define LOAD_IMAGE_POINTER(object) (static_cast<mapnik::image_rgba8*>(LOAD_OBJECT_POINTER(object)))
 
 static void init_class(JNIEnv* env, const char* name, jclass& classref) {
 	classref=(jclass)env->NewGlobalRef(env->FindClass(name));

--- a/csrc/mapnikjni.cpp
+++ b/csrc/mapnikjni.cpp
@@ -4,14 +4,19 @@
 #include <mapnik/load_map.hpp>
 #include <mapnik/layer.hpp>
 #include <mapnik/feature_type_style.hpp>
+#include <mapnik/datasource.hpp>
 #include <mapnik/datasource_cache.hpp>
 #include <mapnik/attribute_collector.hpp>
 #include <mapnik/save_map.hpp>
 #include <mapnik/feature.hpp>
-#include <mapnik/graphics.hpp>
 #include <mapnik/image_util.hpp>
 #include <mapnik/agg_renderer.hpp>
 #include <mapnik/font_engine_freetype.hpp>
+#include <mapnik/geometry_type.hpp>
+#include <mapnik/projection.hpp>
+#include <mapnik/vertex_processor.hpp>
+
+#include <boost/variant/static_visitor.hpp>
 
 #include "mapnikjni.h"
 #include "globals.cpp"

--- a/csrc/mapnikjni.h
+++ b/csrc/mapnikjni.h
@@ -7,14 +7,20 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#undef mapnik_Parameters_serialVersionUID
+#define mapnik_Parameters_serialVersionUID 362498820763181265LL
 #undef mapnik_Parameters_DEFAULT_INITIAL_CAPACITY
 #define mapnik_Parameters_DEFAULT_INITIAL_CAPACITY 16L
 #undef mapnik_Parameters_MAXIMUM_CAPACITY
 #define mapnik_Parameters_MAXIMUM_CAPACITY 1073741824L
 #undef mapnik_Parameters_DEFAULT_LOAD_FACTOR
 #define mapnik_Parameters_DEFAULT_LOAD_FACTOR 0.75f
-#undef mapnik_Parameters_serialVersionUID
-#define mapnik_Parameters_serialVersionUID 362498820763181265LL
+#undef mapnik_Parameters_TREEIFY_THRESHOLD
+#define mapnik_Parameters_TREEIFY_THRESHOLD 8L
+#undef mapnik_Parameters_UNTREEIFY_THRESHOLD
+#define mapnik_Parameters_UNTREEIFY_THRESHOLD 6L
+#undef mapnik_Parameters_MIN_TREEIFY_CAPACITY
+#define mapnik_Parameters_MIN_TREEIFY_CAPACITY 64L
 /*
  * Class:     mapnik_Parameters
  * Method:    setNativeInt
@@ -50,13 +56,6 @@ JNIEXPORT void JNICALL Java_mapnik_Parameters_setNativeDouble
 #ifdef __cplusplus
 extern "C" {
 #endif
-/* Inaccessible static: initialized */
-/* Inaccessible static: registered */
-/* Inaccessible static: loadedLibrary */
-/* Inaccessible static: librarySearchNames */
-/* Inaccessible static: librarySearchPath */
-/* Inaccessible static: initializationFailure */
-/* Inaccessible static: nativeAllocCounts */
 /*
  * Class:     mapnik_Mapnik
  * Method:    nativeInit

--- a/src/mapnik/Mapnik.java
+++ b/src/mapnik/Mapnik.java
@@ -2,10 +2,8 @@ package mapnik;
 
 import java.io.File;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
@@ -18,36 +16,7 @@ import java.util.regex.Pattern;
 public class Mapnik {
 	private static boolean initialized;
 	private static boolean registered;
-	private static String loadedLibrary;
-	private static List<String> librarySearchNames=new ArrayList<String>();
-	private static List<String> librarySearchPath=new ArrayList<String>();
 	private static boolean initializationFailure;
-	
-	static {
-		librarySearchNames.add("mapnik-jni");
-		
-		// Discover where we are
-		URL url=Mapnik.class.getResource("/mapnik/Mapnik.class");
-		if (url!=null) {
-			//System.err.println("Jar url=" + url);
-			// URL should be of the form jar:file:...!/mapnik/Mapnik.class
-			String urlString=url.toString();
-			String prefix="jar:file:";
-			String suffix="!/mapnik/Mapnik.class";
-			if (urlString.startsWith(prefix) && urlString.endsWith(suffix)) {
-				String jarFile=urlString.substring(prefix.length(), urlString.length() - suffix.length());
-				File jarPath=new File(jarFile).getParentFile();
-				librarySearchPath.add(jarPath.getAbsolutePath());
-			}
-		}
-		
-		// Add java.library.path names
-		String sysLibraryPath=System.getProperty("java.library.path");
-		if (sysLibraryPath!=null) {
-			String[] paths=sysLibraryPath.split(Pattern.quote(File.pathSeparator));
-			for (String path: paths) librarySearchPath.add(path);
-		}
-	}
 	
 	private static Map<Class<? extends NativeObject>, AtomicInteger> nativeAllocCounts;
 	static {
@@ -110,72 +79,8 @@ public class Mapnik {
 		i.addAndGet(delta);
 	}
 	
-	private static boolean tryLoadLibrary(String path) {
-		if (loadedLibrary!=null) return true;
-		
-		File file=new File(path);
-		if (file.isFile()) {
-			// Load it without error checking.  We want the first that exists.
-			System.load(file.getAbsolutePath());
-			loadedLibrary=path;
-			return true;
-		} else {
-			return false;
-		}
-	}
-	
-	private static void loadLibrary() {
-		if (loadedLibrary!=null) return;
-		
-		for (String path: librarySearchPath) {
-			for (String name: librarySearchNames) {
-				String mappedName=System.mapLibraryName(name);
-				String libPath=path + File.separator + mappedName;
-				if (tryLoadLibrary(libPath)) return;
-			}
-		}
-		
-		// Report
-		String message="Unable to find mapnik-jni library.  Search names=" +
-			Arrays.toString(librarySearchNames.toArray()) +
-			", Search path=" + Arrays.toString(librarySearchPath.toArray());
-		throw new LinkageError(message);
-	}
-	
 	/**
-	 * If initialized, this is the full path of the loaded library
-	 * @return path of library
-	 */
-	public static String getLoadedLibrary() {
-		return loadedLibrary;
-	}
-	
-	/**
-	 * @return modifiable list of library search names to be probed on initialize
-	 */
-	public static List<String> getLibrarySearchNames() {
-		return librarySearchNames;
-	}
-
-	/**
-	 * The library search path.  This defaults to the directory containing
-	 * this jar file (if found) followed by all entries on java.library.path.
-	 * The system default path is implied.
-	 * 
-	 * @return modifiable list of library search paths to be probed on initialize
-	 */
-	public static List<String> getLibrarySearchPath() {
-		return librarySearchPath;
-	}
-	
-	/**
-	 * Initialize the mapnik library.  Relies on the following to have been set prior to
-	 * call:
-	 * <ul>
-	 * <li>getLibrarySearchNames()
-	 * <li>getLibrarySearchPath()
-	 * </ul>
-	 * In most situations, the defaults should suffice.
+	 * Initialize the mapnik library.
 	 * @param register If true, then also register input plugins and fonts
 	 */
 	public synchronized static void initialize(boolean register) {
@@ -183,7 +88,7 @@ public class Mapnik {
 			if (initializationFailure) {
 				throw new IllegalStateException("Previous call to Mapnik.initialize() failed");
 			}
-			loadLibrary();
+			System.loadLibrary("mapnik-jni");
 	
 			try {
 				nativeInit();
@@ -216,7 +121,7 @@ public class Mapnik {
 	}
 	
 	/**
-	 * Equivilent to initialize(true).  Fully links and initializes the mapnik library.
+	 * Equivalent to initialize(true).  Fully links and initializes the mapnik library.
 	 */
 	public static void initialize() {
 		initialize(true);

--- a/test/mapnik/Setup.java
+++ b/test/mapnik/Setup.java
@@ -2,11 +2,7 @@ package mapnik;
 
 
 public class Setup {
-	private static boolean inited=false;
-	
 	public static void initialize() {
-		if (inited) return;
-		inited=true;
 		Mapnik.initialize();
 	}
 	

--- a/test/mapnik/TestLoadLibrary.java
+++ b/test/mapnik/TestLoadLibrary.java
@@ -13,12 +13,9 @@ import static org.junit.Assert.*;
  */
 public class TestLoadLibrary {
 	@Test
-	public void testInitialize() {
-		Mapnik.initialize();
-	}
-	
-	@Test
 	public void testPluginAndFontPaths() {
+		Mapnik.initialize();
+
 		System.err.println("Installed fonts dir=" + Mapnik.getInstalledFontsDir());
 		System.err.println("Installed plugin dir=" + Mapnik.getInstalledInputPluginsDir());
 		

--- a/test/mapnik/TestLoadLibrary.java
+++ b/test/mapnik/TestLoadLibrary.java
@@ -13,14 +13,8 @@ import static org.junit.Assert.*;
  */
 public class TestLoadLibrary {
 	@Test
-	public void testStaticSettings() {
-		System.err.println("Search path=" + Arrays.toString(Mapnik.getLibrarySearchPath().toArray()));
-		String expected=new File("build/dist").getAbsolutePath();
-		assertEquals("Jar relative search path (will only succeed if testing from jar)", 
-				expected, Mapnik.getLibrarySearchPath().get(0));
-		
+	public void testInitialize() {
 		Mapnik.initialize();
-		assertEquals(new File(expected, System.mapLibraryName("mapnik-jni")).toString(), Mapnik.getLoadedLibrary());
 	}
 	
 	@Test


### PR DESCRIPTION
I'm trying to render OSM tiles from Java on Windows and OS X. I couldn't get mapnik-jni to link on Windows at first (same error as in issue #3), and when I did, things crashed as soon as I zoomed to an area that actually contained anything.

So I've adapted mapnik-jni to work with Mapnik 3; specifically, Mapnik 3.0.1 from Homebrew on OS X, and the 64-bit Mapnik 3.0.2 SDK for Windows linked to from this comment: https://github.com/mapnik/mapnik/issues/3014#issuecomment-127180550
(I can send a separate Pull Request for my MSVC 2015 project if this PR looks okay to you.)

All tests pass and everything works fine for me, but so far I've only loaded maps from XML and rendered them to PNG, so it is entirely possible that I've broken every other class on my way.
I'll comment on the commits in this PR about which I feel a little uneasy. Also, I haven't added any `#ifdef` magic to keep this compatible with Mapnik 2.x.
